### PR TITLE
Refactor caching mechanism to in-memory storage and update SaveChangesAsync call

### DIFF
--- a/server/Controllers/SummarizeController.cs
+++ b/server/Controllers/SummarizeController.cs
@@ -142,6 +142,7 @@ public class SummarizeController(SummarizerDbContext dbContext, SummaryService s
                 }
             }
 
+            await _dbContext.SaveChangesAsync();
             return Ok(new { type = "article", input_text = summary.ArticleText, summary_text = summary.SummaryText });
         }
         catch (Exception ex)

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -3,16 +3,14 @@ using Microsoft.EntityFrameworkCore;
 using server.Data;
 using server.Models;
 using server.Services;
-using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
 var postgresConnectionString = Environment.GetEnvironmentVariable("POSTGRES_CONNECTION_STRING");
-var redisConnectionString = Environment.GetEnvironmentVariable("REDIS_CONNECTION_STRING");
 
-if (string.IsNullOrEmpty(postgresConnectionString) || string.IsNullOrEmpty(redisConnectionString))
+if (string.IsNullOrEmpty(postgresConnectionString))
 {
-    throw new InvalidOperationException("POSTGRES_CONNECTION_STRING and REDIS_CONNECTION_STRING environment variables must be set.");
+    throw new InvalidOperationException("POSTGRES_CONNECTION_STRING");
 }
 
 builder.Services.AddDbContext<SummarizerDbContext>(options =>
@@ -20,11 +18,7 @@ builder.Services.AddDbContext<SummarizerDbContext>(options =>
     options.UseNpgsql(postgresConnectionString);
 });
 
-builder.Services.AddStackExchangeRedisCache(options =>
-{
-    options.Configuration = redisConnectionString;
-    options.InstanceName = "Summarizer_";
-});
+builder.Services.AddMemoryCache();
 
 builder.Services.AddIdentityApiEndpoints<User>()
     .AddEntityFrameworkStores<SummarizerDbContext>()
@@ -44,7 +38,6 @@ builder.Services.AddAuthorization();
 builder.Services.AddHttpClient<SummaryService>();
 builder.Services.AddScoped<SummaryService>();
 builder.Services.AddScoped<UserAccessService>();
-builder.Services.AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(redisConnectionString));
 builder.Services.AddControllers();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/server/server.csproj
+++ b/server/server.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />


### PR DESCRIPTION
Replace Redis caching with in-memory caching for improved performance and simplify the SaveChangesAsync call in the SummarizeController. Clean up methods in SummaryService for better readability.